### PR TITLE
Zusätzlicher Hinweis für monatliche Wartung (2.3)

### DIFF
--- a/Einweisung_Fraese.tex
+++ b/Einweisung_Fraese.tex
@@ -177,6 +177,7 @@ An allen HSK-Einsätzen die Kegel- und Planfläche (siehe \cref{fig:hsk-einsatz}
 	\item Kühlwasserstand Kühlgerät prüfen, ob er über der roten Markierung ist, wenn das Gerät läuft. (Rot: Minimum, Blau: Halbvoll, das Maximum ist im Gerät am Tank gekennzeichnet.)
 	\item „Metaflux Moly-Spray 70.82“ gut schütteln (Feststoffanteil!)
 	\item Den Greifer in der Mitte der HSK-Aufnahme damit schmieren. Das Moly-Spray (graue Flüssigkeit) dazu in die 6 Lücken zwischen den Segmenten des Greifers aufbringen (\cref{fig:hsk-greifer}). 
+	\item Den Innenkegel mit einem Papiertuch abputzen, damit nicht durch (zu viel) Schmiermittel der Kegel "festklebt". Wenn das doch passiert ist, kann durch vorsichtiges, seitliches schlagen mit dem Schonhammer der Kegel gelöst werden, während man die Auswechseltaste betätigt.
 	\item Mehrmals HSK-Einsatz ein- und auswechseln, um Schmiermittel zu verteilen. Dabei Schmiermittel abputzen, das am Einsatz hängen bleibt.
 	\item Greifer und alles andere mit Papiertuch abputzen, um überschüssiges Schmiermittel zu entfernen.
 	\item Spindel kurz laufen lassen (z.B. mit Warmlaufprogramm), wieder ausschalten. Nochmal HSK-Einsatz auswechseln und putzen.


### PR DESCRIPTION
Während des Crashkurses für die Fräse ist uns aufgefallen das auftretende Kapillarkräfte, durch das Schmiermittel, einen Wechsel des HSK Kegels behindern kann. Entsprechend die passende Änderung in der Einweisung. 